### PR TITLE
 CRT Buffer Overrun detected when function name is very long 

### DIFF
--- a/Main/StackWalker/StackWalker.cpp
+++ b/Main/StackWalker/StackWalker.cpp
@@ -651,7 +651,7 @@ private:
     pGMI = (tGMI) GetProcAddress( hPsapi, "GetModuleInformation" );
     if ( (pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL) )
     {
-      // we couldn´t find all functions
+      // we couldnï¿½t find all functions
       FreeLibrary(hPsapi);
       return FALSE;
     }
@@ -1305,10 +1305,10 @@ void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry &ent
       MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, "(filename not available)");
       if (entry.moduleName[0] == 0)
         MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, "(module-name not available)");
-      _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%p (%s): %s: %s\n", (LPVOID) entry.offset, entry.moduleName, entry.lineFileName, entry.name);
+      _snprintf_s(buffer, _TRUNCATE, "%p (%s): %s: %s\n", (LPVOID) entry.offset, entry.moduleName, entry.lineFileName, entry.name);
     }
     else
-      _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber, entry.name);
+      _snprintf_s(buffer, _TRUNCATE, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber, entry.name);
     buffer[STACKWALK_MAX_NAMELEN-1] = 0;
     OnOutput(buffer);
   }

--- a/Main/StackWalker/StackWalker.cpp
+++ b/Main/StackWalker/StackWalker.cpp
@@ -651,7 +651,7 @@ private:
     pGMI = (tGMI) GetProcAddress( hPsapi, "GetModuleInformation" );
     if ( (pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL) )
     {
-      // we couldn�t find all functions
+      // we couldn't find all functions
       FreeLibrary(hPsapi);
       return FALSE;
     }


### PR DESCRIPTION
I experienced a crashed when using StackWalker, when the of a function on the stack does not fit in the _snprintf_s buffer, so if the resulting string is longer then STACKWALK_MAX_NAMELEN (1024). In that case, CRT terminates the process. This can happen e.g. when using boost data structures that use a lot of templates (e.g. boost::unordered::detail::func::construct_value_impl<std::allocator<boost::unordered::detail::ptr_node<std::pair<boost::thread::id const ,std::vector<cncsim::mwCNCSimApiLogger::CallInfo,std::allocatorcncsim::mwCNCSimApiLogger::CallInfo > > > >,boost::thread::id const ,std::vector<cncsim::mwCNCSimApiLogger::CallInfo,std::allocatorcncsim::mwCNCSimApiLogger::CallInfo >,boost::unordered::piecewise_construct_t const & __ptr64,boost::tuples::tupleboost::thread::id,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::tupleboost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type >)

Using _TRUNCATE when calling _snprintf_s, will truncate the function name instead of treating this as an error (see https://msdn.microsoft.com/en-us/library/ms175769.aspx)