### PR TITLE
Include parts of "windows.h", examples of solving template name conflicts.

### DIFF
--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -36,7 +36,23 @@
 // so we need not to check the version (because we only support _MSC_VER >= 1100)!
 #pragma once
 
-#include <windows.h>
+// include all it - bad way
+//#include <windows.h>
+
+// better include needed parts
+#include <windef.h>
+#include <WinBase.h>
+#include <stdlib.h>
+
+// and undef annoying defines
+#undef GetFreeSpace
+#undef CREATE_NEW
+#undef min
+#undef max
+#undef ERROR_UNHANDLED_EXCEPTION
+#undef CreateDirectory
+#undef DeleteFile
+// ... undef more if need 
 
 #if _MSC_VER >= 1900
 #pragma warning(disable : 4091)

--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -41,17 +41,40 @@
 
 // better include needed parts
 #include <windef.h>
+//#define _M_CEE // DeleteFile
 #include <WinBase.h>
 #include <stdlib.h>
 
 // and undef annoying defines
 #undef GetFreeSpace
-#undef CREATE_NEW
 #undef min
 #undef max
 #undef ERROR_UNHANDLED_EXCEPTION
 #undef CreateDirectory
+
+#undef CREATE_NEW
+const int CREATE_NEW = 1;
+#undef SEVERITY_ERROR
+const int SEVERITY_ERROR = 1;
+
 #undef DeleteFile
+__inline
+BOOL
+DeleteFile(LPCTSTR lpFileName)
+{
+#ifdef UNICODE
+  return DeleteFileW(
+#else
+  return DeleteFileA(
+#endif
+    lpFileName
+  );
+}
+
+#undef ERROR_UNKNOWN_COMPONENT
+#undef RequestImpl
+#undef GetStartupInfo
+#undef ERROR_TAG_NOT_FOUND 
 // ... undef more if need 
 
 #if _MSC_VER >= 1900

--- a/Main/StackWalker/StackWalker_VC2015.vcxproj
+++ b/Main/StackWalker/StackWalker_VC2015.vcxproj
@@ -430,7 +430,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_AMD64_</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>


### PR DESCRIPTION
Include parts of "windows.h", examples solving template name conflicts.
Default architecture amd x64, not itanium.