### PR TITLE
Adding support for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,77 @@
+project(StackWalker-project)
+
+cmake_minimum_required(VERSION 3.5)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+    #set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+
+option(StackWalker_DISABLE_TESTS  "Disable tests" OFF)
+
+
+###############################
+# Check compiler's capabilities
+###############################
+
+include (CheckCXXCompilerFlag)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set (CMAKE_COMPILER_IS_CLANG true)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    set (CMAKE_COMPILER_IS_MSVC true)
+endif()
+
+if(CMAKE_COMPILER_IS_MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_SECURE_SCL=0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_DEPRECATE")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_NONSTDC_NO_DEPRECATE")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_SCL_SECURE_NO_DEPRECATE")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Zi")
+else()
+    message(FATAL_ERROR "${CMAKE_CXX_COMPILER_ID} is not supported yet")
+endif()
+
+message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
+set (CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include")
+set (CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib")
+set (CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/bin")
+message(STATUS "CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
+message(STATUS "CMAKE_INSTALL_LIBDIR: ${CMAKE_INSTALL_LIBDIR}")
+message(STATUS "CMAKE_INSTALL_BINDIR: ${CMAKE_INSTALL_BINDIR}")
+
+set(TARGET_StackWalker StackWalker)
+add_library(${TARGET_StackWalker} STATIC
+    Main/StackWalker/StackWalker.cpp)
+target_include_directories(${TARGET_StackWalker} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Main/StackWalker>
+    )
+
+install(TARGETS "${TARGET_StackWalker}"
+    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+
+install(FILES "${CMAKE_SOURCE_DIR}/Main/StackWalker/StackWalker.h"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_StackWalker}.dir/$\{CMAKE_INSTALL_CONFIG_NAME\}/${TARGET_StackWalker}.pdb"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR} OPTIONAL)
+
+
+if (StackWalker_DISABLE_TESTS)
+    message(STATUS "Skipping tests")
+else()
+    enable_testing()
+
+    set(TARGET_StackWalker_tests StackWalker_test)
+    add_executable(${TARGET_StackWalker_tests}
+        Main/StackWalker/main.cpp)
+    target_link_libraries(${TARGET_StackWalker_tests} PUBLIC ${TARGET_StackWalker})
+
+    add_test(NAME ${TARGET_StackWalker_tests} COMMAND ${TARGET_StackWalker_tests})
+endif()

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ This project only supports the newer Xxx64-funtions. If you need to use it on ol
 The latest *dbghelp.dll* can always be downloaded with the [Debugging Tools for Windows](http://www.microsoft.com/whdc/devtools/debugging/).
 This also contains the *symsrv.dll* which enables the use of the public Microsoft symbols-server (can be used to retrieve debugging information for system-files; see below).
 
+## Build
+
+```
+mkdir build-dir
+cd build-dir
+cmake -G "Visual Studio 15 2017 Win64" --config RelWithDebInfo -DCMAKE_INSTALL_PREFIX=%cd%/root ..
+cmake --build . --config RelWithDebInfo
+ctest.exe -V -C RelWithDebInfo
+cmake --build . --target install --config RelWithDebInfo
+```
+
 ## Using the code
 
 The usage of the class is very simple. For example if you want to display the callstack of the current thread, just instantiate a `StackWalk` object and call the `ShowCallstack` member:


### PR DESCRIPTION
Files:
- CMakeLists.txt
- Add a paragraph for build in README.md

I set by default `/W4` for warnings (cf. [MSVC warning levels](https://msdn.microsoft.com/en-us/library/thxezb7y.aspx)) and got 4 warnings.
```
cmake -G "Visual Studio 15 2017 Win64" --config RelWithDebInfo -DCMAKE_INSTALL_PREFIX=%cd%/root ..
-- The C compiler identification is MSVC 19.14.26430.0
-- The CXX compiler identification is MSVC 19.14.26430.0
-- Check for working C compiler: D:/Program Files/Microsoft Visual Studio 15.0/VC/Tools/MSVC/14.14.26428/bin/Hostx86/x64/cl.exe
-- Check for working C compiler: D:/Program Files/Microsoft Visual Studio 15.0/VC/Tools/MSVC/14.14.26428/bin/Hostx86/x64/cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: D:/Program Files/Microsoft Visual Studio 15.0/VC/Tools/MSVC/14.14.26428/bin/Hostx86/x64/cl.exe
-- Check for working CXX compiler: D:/Program Files/Microsoft Visual Studio 15.0/VC/Tools/MSVC/14.14.26428/bin/Hostx86/x64/cl.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CMAKE_INSTALL_PREFIX: C:/Users/mlongo/Documents/StackWalker/build-dir/root
-- CMAKE_INSTALL_INCLUDEDIR: C:/Users/mlongo/Documents/StackWalker/build-dir/root/include
-- CMAKE_INSTALL_LIBDIR: C:/Users/mlongo/Documents/StackWalker/build-dir/root/lib
-- CMAKE_INSTALL_BINDIR: C:/Users/mlongo/Documents/StackWalker/build-dir/root/bin
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/mlongo/Documents/StackWalker/build-dir

C:\Users\mlongo\Documents\StackWalker\build-dir>cmake --build . --config RelWithDebInfo
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

Build started 10/07/2018 15:16:44.
Project "C:\Users\mlongo\Documents\StackWalker\build-dir\ALL_BUILD.vcxproj" on node 1 (default targets).
Project "C:\Users\mlongo\Documents\StackWalker\build-dir\ALL_BUILD.vcxproj" (1) is building "C:\Users\mlongo\Documents\StackWalker\build-dir\ZERO_CHECK.vcxproj" (2) on node 1 (default targets).
PrepareForBuild:
  Creating directory "x64\RelWithDebInfo\ZERO_CHECK\".
  Creating directory "x64\RelWithDebInfo\ZERO_CHECK\ZERO_CHECK.tlog\".
InitializeBuildStatus:
  Creating "x64\RelWithDebInfo\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
CustomBuild:
  Checking Build System
  CMake does not need to re-run because C:/Users/mlongo/Documents/StackWalker/build-dir/CMakeFiles/generate.stamp is up-to-date.
FinalizeBuildStatus:
  Deleting file "x64\RelWithDebInfo\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild".
  Touching "x64\RelWithDebInfo\ZERO_CHECK\ZERO_CHECK.tlog\ZERO_CHECK.lastbuildstate".
Done Building Project "C:\Users\mlongo\Documents\StackWalker\build-dir\ZERO_CHECK.vcxproj" (default targets).

Project "C:\Users\mlongo\Documents\StackWalker\build-dir\ALL_BUILD.vcxproj" (1) is building "C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj" (3) on node 1 (default targets).
PrepareForBuild:
  Creating directory "StackWalker.dir\RelWithDebInfo\".
  Creating directory "C:\Users\mlongo\Documents\StackWalker\build-dir\RelWithDebInfo\".
  Creating directory "StackWalker.dir\RelWithDebInfo\StackWalker.tlog\".
InitializeBuildStatus:
  Creating "StackWalker.dir\RelWithDebInfo\StackWalker.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
CustomBuild:
  Building Custom Rule C:/Users/mlongo/Documents/StackWalker/CMakeLists.txt
  CMake does not need to re-run because C:/Users/mlongo/Documents/StackWalker/build-dir/CMakeFiles/generate.stamp is up-to-date.
ClCompile:
  D:\Program Files\Microsoft Visual Studio 15.0\VC\Tools\MSVC\14.14.26428\bin\HostX86\x64\CL.exe /c /IC:\Users\mlongo\Documents\StackWalker\Main\StackWalker /Zi /nologo /W4 /WX- /diagnostics:classic /O2 /Ob1 /D WIN32 /D _WINDOWS /D _SEC
  URE_SCL=0 /D _CRT_SECURE_NO_DEPRECATE /D _CRT_NONSTDC_NO_DEPRECATE /D _SCL_SECURE_NO_DEPRECATE /D NDEBUG /D "CMAKE_INTDIR=\"RelWithDebInfo\"" /D _MBCS /Gm- /EHsc /MD /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR /Fo"StackWal
  ker.dir\RelWithDebInfo\\" /Fd"StackWalker.dir\RelWithDebInfo\vc141.pdb" /Gd /TP /FC /errorReport:queue C:\Users\mlongo\Documents\StackWalker\Main\StackWalker\main.cpp C:\Users\mlongo\Documents\StackWalker\Main\StackWalker\StackWalker.
  cpp
  main.cpp
c:\users\mlongo\documents\stackwalker\main\stackwalker\main.cpp(165): warning C4245: 'argument': conversion from 'int' to 'UINT', signed/unsigned mismatch [C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj]
c:\users\mlongo\documents\stackwalker\main\stackwalker\main.cpp(190): warning C4100: 'dwExpCode': unreferenced formal parameter [C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj]
c:\users\mlongo\documents\stackwalker\main\stackwalker\main.cpp(221): warning C4100: 'argv': unreferenced formal parameter [C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj]
c:\users\mlongo\documents\stackwalker\main\stackwalker\main.cpp(221): warning C4100: 'argc': unreferenced formal parameter [C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj]
  StackWalker.cpp
  Generating Code...
Link:
  D:\Program Files\Microsoft Visual Studio 15.0\VC\Tools\MSVC\14.14.26428\bin\HostX86\x64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\Users\mlongo\Documents\StackWalker\build-dir\RelWithDebInfo\StackWalker.exe" /INCREMENTAL /NOLOGO kernel32.li
  b user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /DEBUG /PDB:"C:/Users/mlongo/Documents/StackWalker/b
  uild-dir/RelWithDebInfo/StackWalker.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"C:/Users/mlongo/Documents/StackWalker/build-dir/RelWithDebInfo/StackWalker.lib" /MACHINE:X64  /machine:x64 StackWalker.dir\RelWithDeb
  Info\main.obj
  StackWalker.dir\RelWithDebInfo\StackWalker.obj
  StackWalker.vcxproj -> C:\Users\mlongo\Documents\StackWalker\build-dir\RelWithDebInfo\StackWalker.exe
FinalizeBuildStatus:
  Deleting file "StackWalker.dir\RelWithDebInfo\StackWalker.tlog\unsuccessfulbuild".
  Touching "StackWalker.dir\RelWithDebInfo\StackWalker.tlog\StackWalker.lastbuildstate".
Done Building Project "C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj" (default targets).

PrepareForBuild:
  Creating directory "x64\RelWithDebInfo\ALL_BUILD\".
  Creating directory "x64\RelWithDebInfo\ALL_BUILD\ALL_BUILD.tlog\".
InitializeBuildStatus:
  Creating "x64\RelWithDebInfo\ALL_BUILD\ALL_BUILD.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
CustomBuild:
  Building Custom Rule C:/Users/mlongo/Documents/StackWalker/CMakeLists.txt
  CMake does not need to re-run because C:/Users/mlongo/Documents/StackWalker/build-dir/CMakeFiles/generate.stamp is up-to-date.
FinalizeBuildStatus:
  Deleting file "x64\RelWithDebInfo\ALL_BUILD\ALL_BUILD.tlog\unsuccessfulbuild".
  Touching "x64\RelWithDebInfo\ALL_BUILD\ALL_BUILD.tlog\ALL_BUILD.lastbuildstate".
Done Building Project "C:\Users\mlongo\Documents\StackWalker\build-dir\ALL_BUILD.vcxproj" (default targets).


Build succeeded.

"C:\Users\mlongo\Documents\StackWalker\build-dir\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj" (default target) (3) ->
(ClCompile target) ->
  c:\users\mlongo\documents\stackwalker\main\stackwalker\main.cpp(165): warning C4245: 'argument': conversion from 'int' to 'UINT', signed/unsigned mismatch [C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj]
  c:\users\mlongo\documents\stackwalker\main\stackwalker\main.cpp(190): warning C4100: 'dwExpCode': unreferenced formal parameter [C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj]
  c:\users\mlongo\documents\stackwalker\main\stackwalker\main.cpp(221): warning C4100: 'argv': unreferenced formal parameter [C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj]
  c:\users\mlongo\documents\stackwalker\main\stackwalker\main.cpp(221): warning C4100: 'argc': unreferenced formal parameter [C:\Users\mlongo\Documents\StackWalker\build-dir\StackWalker.vcxproj]

    4 Warning(s)
    0 Error(s)
```