### PR TITLE
[ci] add appveyor.yml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ install(TARGETS "${TARGET_StackWalker}"
 install(FILES "${CMAKE_SOURCE_DIR}/Main/StackWalker/StackWalker.h"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-if (MSVC_VERSION GREATER_EQUAL 1910)
+if (MSVC_VERSION GREATER_EQUAL 1900)
     set(PDB_StackWalker "${TARGET_StackWalker}.pdb")
 else()
     set(PDB_StackWalker "vc${MSVC_TOOLSET_VERSION}.pdb")

--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -222,13 +222,13 @@ protected:
     c.ContextFlags = contextFlags;                                              \
   } while (0);
 #else
+// clang-format off
 // The following should be enough for walking the callstack...
 #define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
   do                                                              \
   {                                                               \
     memset(&c, 0, sizeof(CONTEXT));                               \
     c.ContextFlags = contextFlags;                                \
-  // clang-format off                                             \
     __asm {                                                       \
         call x                                                    \
      x: pop eax                                                   \
@@ -236,8 +236,8 @@ protected:
         mov c.Ebp, ebp                                            \
         mov c.Esp, esp                                            \
     };                                                            \
-  // clang-format on                                              \
   } while (0);
+// clang-format on
 #endif
 
 #else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: "{branch}-ci-{build}"
+
+environment:
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+
+build_script:
+    - ps: cmake --version
+    - ps: cmake -E make_directory "build-dir"
+    - ps: cmake -E chdir "build-dir" cmake -G "$($(Get-Item Env:CMAKE_GENERATOR).Value)" --config RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$($(get-location).Path)/root" ..
+    - ps: cmake --build "build-dir" --config RelWithDebInfo
+    - ps: cmake --build "build-dir" --target install --config RelWithDebInfo


### PR DESCRIPTION
I would like to add a CI that would help you get a clear status before validating pull requests without having to do it yourself on your machine.
I created an account on [AppVeyor](https://ci.appveyor.com/) using my github account.
You can see on [this page](https://ci.appveyor.com/project/matlo607/stackwalker/build/add-ci-appveyor-ci-4) a sum up of 3 builds (Visual Studio 2013, 2015 and 2017).
I noticed I introduced a regression with the last pull request for clang-format.
```
 C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.14.26428\bin\HostX86\x64\CL.exe /c /IC:\projects\stackwalker\Main\StackWalker /I"C:\Tools\vcpkg\installed\x64-windows\include" /Zi /nologo /W4 /WX- /diagnostics:classic /O2 /Ob1 /D WIN32 /D _WINDOWS /D _SECURE_SCL=0 /D _CRT_SECURE_NO_DEPRECATE /D _CRT_NONSTDC_NO_DEPRECATE /D _SCL_SECURE_NO_DEPRECATE /D NDEBUG /D "CMAKE_INTDIR=\"RelWithDebInfo\"" /D _MBCS /Gm- /EHsc /MD /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR /Fo"StackWalker.dir\RelWithDebInfo\\" /Fd"StackWalker.dir\RelWithDebInfo\StackWalker.pdb" /Gd /TP /FC /errorReport:queue C:\projects\stackwalker\Main\StackWalker\StackWalker.cpp
  StackWalker.cpp
c:\projects\stackwalker\main\stackwalker\stackwalker.h(232): warning C4010: single-line comment contains line-continuation character [C:\projects\stackwalker\build-dir\StackWalker.vcxproj]
c:\projects\stackwalker\main\stackwalker\stackwalker.h(233): warning C4010: single-line comment contains line-continuation character [C:\projects\stackwalker\build-dir\StackWalker.vcxproj]
c:\projects\stackwalker\main\stackwalker\stackwalker.h(234): warning C4010: single-line comment contains line-continuation character [C:\projects\stackwalker\build-dir\StackWalker.vcxproj]
c:\projects\stackwalker\main\stackwalker\stackwalker.h(235): warning C4010: single-line comment contains line-continuation character [C:\projects\stackwalker\build-dir\StackWalker.vcxproj]
c:\projects\stackwalker\main\stackwalker\stackwalker.h(236): warning C4010: single-line comment contains line-continuation character [C:\projects\stackwalker\build-dir\StackWalker.vcxproj]
c:\projects\stackwalker\main\stackwalker\stackwalker.h(237): warning C4010: single-line comment contains line-continuation character [C:\projects\stackwalker\build-dir\StackWalker.vcxproj]
c:\projects\stackwalker\main\stackwalker\stackwalker.h(238): warning C4010: single-line comment contains line-continuation character [C:\projects\stackwalker\build-dir\StackWalker.vcxproj]
c:\projects\stackwalker\main\stackwalker\stackwalker.h(240): warning C4010: single-line comment contains line-continuation character [C:\projects\stackwalker\build-dir\StackWalker.vcxproj]
```
Full logs are available on [this page](https://ci.appveyor.com/project/matlo607/stackwalker/build/add-ci-appveyor-ci-4/job/ropncav9fxeu0w8l).
It looks a lot like travis-ci.
Do you mind creating an account on [AppVeyor](https://ci.appveyor.com/) and register your project on it?
