### PR TITLE
Add custom function table access

### DIFF
--- a/Main/StackWalker/StackWalker.cpp
+++ b/Main/StackWalker/StackWalker.cpp
@@ -1549,11 +1549,3 @@ void StackWalker::OnOutput(LPCSTR buffer)
 {
   OutputDebugStringA(buffer);
 }
-
-PVOID StackWalker::MySymFunctionTableAccess64(HANDLE hProcess, DWORD64 AddrBase) {
-  PVOID addr = SymFunctionTableAccess64(hProcess, AddrBase);
-  DWORD64              ImageBase;
-  UNWIND_HISTORY_TABLE HistoryTable;
-  addr = RtlLookupFunctionEntry(AddrBase, &ImageBase, &HistoryTable);
-  return addr;
-}

--- a/Main/StackWalker/StackWalker.cpp
+++ b/Main/StackWalker/StackWalker.cpp
@@ -91,6 +91,7 @@
 #include <new>
 
 #pragma comment(lib, "version.lib") // for "VerQueryValue"
+#pragma comment(lib, "dbghelp.lib")
 
 #pragma warning(disable : 4826)
 #if _MSC_VER >= 1900

--- a/Main/StackWalker/StackWalker.cpp
+++ b/Main/StackWalker/StackWalker.cpp
@@ -261,7 +261,6 @@ public:
     m_hDbhHelp = NULL;
     pSC = NULL;
     m_hProcess = hProcess;
-    pSFTA = NULL;
     pSGLFA = NULL;
     pSGMB = NULL;
     pSGMI = NULL;
@@ -368,7 +367,6 @@ public:
     pSGO = (tSGO)GetProcAddress(m_hDbhHelp, "SymGetOptions");
     pSSO = (tSSO)GetProcAddress(m_hDbhHelp, "SymSetOptions");
 
-    pSFTA = (tSFTA)GetProcAddress(m_hDbhHelp, "SymFunctionTableAccess64");
     pSGLFA = (tSGLFA)GetProcAddress(m_hDbhHelp, "SymGetLineFromAddr64");
     pSGMB = (tSGMB)GetProcAddress(m_hDbhHelp, "SymGetModuleBase64");
     pSGMI = (tSGMI)GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64");
@@ -377,7 +375,7 @@ public:
     pSLM = (tSLM)GetProcAddress(m_hDbhHelp, "SymLoadModule64");
     pSGSP = (tSGSP)GetProcAddress(m_hDbhHelp, "SymGetSearchPath");
 
-    if (pSC == NULL || pSFTA == NULL || pSGMB == NULL || pSGMI == NULL || pSGO == NULL ||
+    if (pSC == NULL || pSGMB == NULL || pSGMI == NULL || pSGO == NULL ||
         pSGSFA == NULL || pSI == NULL || pSSO == NULL || pSW == NULL || pUDSN == NULL ||
         pSLM == NULL)
     {
@@ -466,10 +464,6 @@ public:
   // SymCleanup()
   typedef BOOL(__stdcall* tSC)(IN HANDLE hProcess);
   tSC pSC;
-
-  // SymFunctionTableAccess64()
-  typedef PVOID(__stdcall* tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
-  tSFTA pSFTA;
 
   // SymGetLineFromAddr64()
   typedef BOOL(__stdcall* tSGLFA)(IN HANDLE hProcess,
@@ -1104,9 +1098,9 @@ static LPVOID s_functionTableAccessFunction_UserData = NULL;
 BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
                                 const CONTEXT*            context,
                                 PReadProcessMemoryRoutine readMemoryFunction,
-                                LPVOID                    pUserData,
+                                LPVOID                    pReadMemoryFunction_userData,
                                 PFunctionTableAccessRoutine functionTableAccessFunction,
-                                LPVOID s_functionTableAccessFunction_UserData)
+                                LPVOID pFunctionTableAccessFunction_UserData)
 {
   CONTEXT                                   c;
   CallstackEntry                            csEntry;
@@ -1127,9 +1121,9 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
   }
 
   s_readMemoryFunction = readMemoryFunction;
-  s_readMemoryFunction_UserData = pUserData;
+  s_readMemoryFunction_UserData = pReadMemoryFunction_userData;
   s_functionTableAccessFunction = functionTableAccessFunction;
-  s_functionTableAccessFunction_UserData = pUserData;
+  s_functionTableAccessFunction_UserData = pFunctionTableAccessFunction_UserData;
 
   if (context == NULL)
   {

--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -213,9 +213,8 @@ protected:
                                       DWORD   nSize,
                                       LPDWORD lpNumberOfBytesRead);
 
-  static PVOID __stdcall myFunctionTableAccessFunction(
-                                      HANDLE hProcess,
-                                      DWORD64 AddrBase);
+  static PVOID __stdcall myFunctionTableAccessFunction(HANDLE hProcess,
+                                                       DWORD64 AddrBase);
 
   friend StackWalkerInternal;
 }; // class StackWalker

--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -136,6 +136,10 @@ public:
       LPVOID  pUserData // optional data, which was passed in "ShowCallstack"
   );
 
+  typedef DWORD64(__stdcall* PGetModuleBase)(IN HANDLE hProcess,
+          IN DWORD64 dwAddr,
+                                             LPVOID  pUserData);
+
   BOOL LoadModules();
 
   BOOL ShowCallstack(
@@ -144,8 +148,10 @@ public:
       PReadProcessMemoryRoutine readMemoryFunction = NULL,
       LPVOID pReadMemoryFunction_userData = NULL, // optional to identify some data in the 'readMemoryFunction'-callback
       PFunctionTableAccessRoutine functionTableAccessFunction = NULL,
-      LPVOID pFunctionTableAccessFunction_UserData = NULL  // optional to identify some data in the 'readMemoryFunction'-callback
-  );
+      LPVOID pFunctionTableAccessFunction_UserData = NULL,  // optional to identify some data in the 'readMemoryFunction'-callback
+      PGetModuleBase getModuleBaseFunction = NULL,
+      LPVOID pGetModuleBaseFunction_UserData = NULL
+              );
 
   BOOL ShowObject(LPVOID pObject);
 
@@ -215,6 +221,8 @@ protected:
 
   static PVOID __stdcall myFunctionTableAccessFunction(HANDLE hProcess,
                                                        DWORD64 AddrBase);
+
+  static DWORD64 __stdcall myGetModuleBaseFunction(HANDLE hProcess, DWORD64 dwAddr);
 
   friend StackWalkerInternal;
 }; // class StackWalker

--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -218,7 +218,6 @@ protected:
                                       DWORD64 AddrBase);
 
   friend StackWalkerInternal;
-  static PVOID MySymFunctionTableAccess64(HANDLE ahProcess, DWORD64 AddrBase);
 }; // class StackWalker
 
 // The "ugly" assembler-implementation is needed for systems before XP

--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -42,6 +42,7 @@
 #pragma once
 
 #include <windows.h>
+#include <DbgHelp.h>
 
 // special defines for VC5/6 (if no actual PSDK is installed):
 #if _MSC_VER < 1300
@@ -129,13 +130,21 @@ public:
       LPVOID  pUserData // optional data, which was passed in "ShowCallstack"
   );
 
+  typedef PVOID(__stdcall* PFunctionTableAccessRoutine)(
+      HANDLE hProcess,
+      DWORD64 AddrBase,
+      LPVOID  pUserData // optional data, which was passed in "ShowCallstack"
+  );
+
   BOOL LoadModules();
 
   BOOL ShowCallstack(
       HANDLE                    hThread = GetCurrentThread(),
       const CONTEXT*            context = NULL,
       PReadProcessMemoryRoutine readMemoryFunction = NULL,
-      LPVOID pUserData = NULL // optional to identify some data in the 'readMemoryFunction'-callback
+      LPVOID pUserData = NULL, // optional to identify some data in the 'readMemoryFunction'-callback
+      PFunctionTableAccessRoutine functionTableAccessFunction = NULL,
+      LPVOID s_functionTableAccessFunction_UserData = NULL  // optional to identify some data in the 'readMemoryFunction'-callback
   );
 
   BOOL ShowObject(LPVOID pObject);
@@ -204,7 +213,12 @@ protected:
                                       DWORD   nSize,
                                       LPDWORD lpNumberOfBytesRead);
 
+  static PVOID __stdcall myFunctionTableAccessFunction(
+                                      HANDLE hProcess,
+                                      DWORD64 AddrBase);
+
   friend StackWalkerInternal;
+  static PVOID MySymFunctionTableAccess64(HANDLE ahProcess, DWORD64 AddrBase);
 }; // class StackWalker
 
 // The "ugly" assembler-implementation is needed for systems before XP

--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -142,9 +142,9 @@ public:
       HANDLE                    hThread = GetCurrentThread(),
       const CONTEXT*            context = NULL,
       PReadProcessMemoryRoutine readMemoryFunction = NULL,
-      LPVOID pUserData = NULL, // optional to identify some data in the 'readMemoryFunction'-callback
+      LPVOID pReadMemoryFunction_userData = NULL, // optional to identify some data in the 'readMemoryFunction'-callback
       PFunctionTableAccessRoutine functionTableAccessFunction = NULL,
-      LPVOID s_functionTableAccessFunction_UserData = NULL  // optional to identify some data in the 'readMemoryFunction'-callback
+      LPVOID pFunctionTableAccessFunction_UserData = NULL  // optional to identify some data in the 'readMemoryFunction'-callback
   );
 
   BOOL ShowObject(LPVOID pObject);

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ class StackWalker
 {
 public:
     BOOL ShowCallstack(HANDLE hThread = GetCurrentThread(), CONTEXT *context = NULL,
-                       PReadProcessMemoryRoutine readMemoryFunction = NULL, LPVOID pUserData = NULL,
+                       PReadProcessMemoryRoutine readMemoryFunction = NULL, LPVOID pReadMemoryFunction_userData = NULL,
                        PFunctionTableAccessRoutine functionTableAccessFunction = NULL, LPVOID pfunctionTableAccessFunction_UserData = NULL);
 };
 ```

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ class StackWalker
 public:
     BOOL ShowCallstack(HANDLE hThread = GetCurrentThread(), CONTEXT *context = NULL,
                        PReadProcessMemoryRoutine readMemoryFunction = NULL, LPVOID pUserData = NULL,
-                       PFunctionTableAccessRoutine functionTableAccessFunction = NULL, LPVOID s_functionTableAccessFunction_UserData = NULL);
+                       PFunctionTableAccessRoutine functionTableAccessFunction = NULL, LPVOID pfunctionTableAccessFunction_UserData = NULL);
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The goal for this project was the following:
 * Support of x86, x64 and IA64 architecture
 * Default output to debugger-output window (but can be customized)
 * Support of user-provided read-memory-function
+* Support of user-provided read-function-table
 * Support of the widest range of development-IDEs (VC5-VC8)
 * Most portable solution to walk the callstack
 
@@ -157,7 +158,8 @@ class StackWalker
 {
 public:
     BOOL ShowCallstack(HANDLE hThread = GetCurrentThread(), CONTEXT *context = NULL,
-                       PReadProcessMemoryRoutine readMemoryFunction = NULL, LPVOID pUserData = NULL);
+                       PReadProcessMemoryRoutine readMemoryFunction = NULL, LPVOID pUserData = NULL,
+                       PFunctionTableAccessRoutine functionTableAccessFunction = NULL, LPVOID s_functionTableAccessFunction_UserData = NULL);
 };
 ```
 


### PR DESCRIPTION
I needed this to provide my own way to access function tables which are dynamically created (e.g. via `RtlAddFunctionTable`).
I think I broke some "retrocompatibility" by adding the ` #pragma comment(lib, "dbghelp.lib")` directive and be able to use `SymFunctionTableAccess64` in the static `myFunctionTableAccessFunction` method. Not sure what would be a better way.

Let me know if it needs adjustments.
