### PR TITLE
Fixed possible deadlocks when calling ShowCallstack() for the same process and a thread that is not the current thread

### DIFF
--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -42,6 +42,7 @@
 #pragma once
 
 #include <windows.h>
+#include <thread>
 
 // special defines for VC5/6 (if no actual PSDK is installed):
 #if _MSC_VER < 1300
@@ -130,6 +131,9 @@ public:
   );
 
   BOOL LoadModules();
+
+  void startMonitoringThread();
+  void stopMonitoringThread();
 
   BOOL ShowCallstack(
       HANDLE                    hThread = GetCurrentThread(),


### PR DESCRIPTION
I have changed StackWalker::ShowCallstack() to be able to retrieve stack dumps from threads of the current process. The previous implementation could easily run into deadlocks when the thread to be analyzed was suspended while holding a critical section that is also used by the caller of ShowCallstack() for instance when it performs memory allocations when calling StackWalk64(). A separate monitoring thread now takes care of the suspending and resuming the thread to be analyzed. It monitors the execution of the thread that executes ShowCallstack() and detects potential deadlock situations properly. In any case the suspended thread is resumed again after some fixed timeout. The ShowCallstack() routine performs up to 5 attempts to retrieve the stack dump before giving up and returning false.

This change also contains a fix for an unlikely but possible situation where OnCallstackEntry gets called with 'lastEntry' and an uninitialized CallstackEntry when the first call to CallStack64() already failed.