### PR TITLE
Zero whole x0 register for arm64 SetUnhandledExceptionFilter return value

### DIFF
--- a/Main/StackWalker/main.cpp
+++ b/Main/StackWalker/main.cpp
@@ -105,10 +105,10 @@ static BOOL PreventSetUnhandledExceptionFilter()
   // C3                   ret
   unsigned char szExecute[] = {0x33, 0xC0, 0xC3};
 #elif _M_ARM64  
-  unsigned char szExecute[] = {
-      0x00, 0x00, 0x80, 0x52, // mov     w0, #0
-      0xC0, 0x03, 0x5F, 0xD6 // ret       
-  };
+	unsigned char szExecute[] = {
+		0x00, 0x00, 0x80, 0xD2, // mov x0, #0
+		0xC0, 0x03, 0x5F, 0xD6 // ret
+	};
 #else
 #error "The following code only works for x86 and x64!"
 #endif


### PR DESCRIPTION
When PreventSetUnhandledExceptionFilter stubs out SetUnhandledExceptionFilter, the stub should return a 64bit zero instead of a 32bit. SetUnhandledExceptionFilter returns a pointer not a 32bit value.