### PR TITLE
Increase minimum CMake version to comply with CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(StackWalker-project)
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
Version CMake 4.0 increases the minimum version requirements and now provides deprecation warnings for setting a minimum version below 3.10