### PR TITLE
inline frames

### DIFF
--- a/Main/StackWalker/StackWalker.cpp
+++ b/Main/StackWalker/StackWalker.cpp
@@ -377,6 +377,10 @@ public:
     pSLM = (tSLM)GetProcAddress(m_hDbhHelp, "SymLoadModule64");
     pSGSP = (tSGSP)GetProcAddress(m_hDbhHelp, "SymGetSearchPath");
 
+    pSAIIT = NULL;
+    pSQIT = NULL;
+    pSFIC = NULL;
+    pSGLFIC = NULL;
     if ((this->m_parent->m_options & StackWalker::SymGetInlineFrames) != 0)
     {
       pSAIIT = (tSAIIT)GetProcAddress(m_hDbhHelp, "SymAddrIncludeInlineTrace");

--- a/Main/StackWalker/StackWalker.cpp
+++ b/Main/StackWalker/StackWalker.cpp
@@ -1236,7 +1236,7 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
     csEntry.name[0] = 0;
     csEntry.undName[0] = 0;
     csEntry.undFullName[0] = 0;
-    csEntry.offsetFromSmybol = 0;
+    csEntry.offsetFromSymbol = 0;
     csEntry.offsetFromLine = 0;
     csEntry.lineFileName[0] = 0;
     csEntry.lineNumber = 0;
@@ -1257,7 +1257,7 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
     {
       // we seem to have a valid PC
       // show procedure info (SymGetSymFromAddr64())
-      if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol),
+      if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSymbol),
                              pSym) != FALSE)
       {
         MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);

--- a/Main/StackWalker/StackWalker.cpp
+++ b/Main/StackWalker/StackWalker.cpp
@@ -399,6 +399,7 @@ public:
     symOptions = this->pSSO(symOptions);
 
     char buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
+    // SymGetSearchPath()
     if (this->pSGSP != NULL)
     {
       if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
@@ -535,6 +536,7 @@ public:
                                          DWORD Flags);
   tUDSN pUDSN;
 
+  // SymGetSearchPath()
   typedef BOOL(__stdcall WINAPI* tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
   tSGSP pSGSP;
 

--- a/Main/StackWalker/StackWalker.cpp
+++ b/Main/StackWalker/StackWalker.cpp
@@ -1411,6 +1411,7 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
               entryType = nextEntry;
 
               ClearCSEntryInline(csEntry);
+              inlineContext++;
             }
           }
           else

--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -91,11 +91,14 @@ public:
     // Also use the public Microsoft-Symbol-Server
     SymUseSymSrv = 0x20,
 
+    // Retrieve inline stack frames
+    SymGetInlineFrames = 0x40,
+
     // Contains all the above "Sym"-options
-    SymAll = 0x30,
+    SymAll = 0x70,
 
     // Contains all options (default)
-    OptionsAll = 0x3F
+    OptionsAll = 0x7F
   } StackWalkOptions;
 
   StackWalker(ExceptType extype, int options = OptionsAll, PEXCEPTION_POINTERS exp = NULL);
@@ -168,6 +171,9 @@ protected:
     DWORD64 baseOfImage;
     CHAR    loadedImageName[STACKWALK_MAX_NAMELEN];
   } CallstackEntry;
+
+  void ClearCSEntry(CallstackEntry& csEntry);
+  void ClearCSEntryInline(CallstackEntry& csEntry);
 
   typedef enum CallstackEntryType
   {

--- a/Main/StackWalker/StackWalker.h
+++ b/Main/StackWalker/StackWalker.h
@@ -158,7 +158,7 @@ protected:
     CHAR    name[STACKWALK_MAX_NAMELEN];
     CHAR    undName[STACKWALK_MAX_NAMELEN];
     CHAR    undFullName[STACKWALK_MAX_NAMELEN];
-    DWORD64 offsetFromSmybol;
+    DWORD64 offsetFromSymbol;
     DWORD   offsetFromLine;
     DWORD   lineNumber;
     CHAR    lineFileName[STACKWALK_MAX_NAMELEN];

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ mkdir build-dir
 cd build-dir
 
 # batch
-cmake -G "Visual Studio 15 2017 Win64" --config RelWithDebInfo -DCMAKE_INSTALL_PREFIX=%cd%/root ..
+cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=%cd%/root ..
 # powershell
-cmake -G "Visual Studio 15 2017 Win64" --config RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$($(get-location).Path)/root" ..
+cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$($(get-location).Path)/root" ..
 
 cmake --build . --config RelWithDebInfo
 ctest.exe -V -C RelWithDebInfo
@@ -358,11 +358,14 @@ typedef enum StackWalkOptions
     // Also use the public Microsoft-Symbol-Server
     SymUseSymSrv = 0x20,
 
+    // Retrieve inline stack frames
+    SymGetInlineFrames = 0x40,
+
     // Contains all the above "Sym"-options
-    SymAll = 0x30,
+    SymAll = 0x70,
 
     // Contains all options (default)
-    OptionsAll = 0x3F
+    OptionsAll = 0x7F
 } StackWalkOptions;
 ```
 


### PR DESCRIPTION
`StackWalker` can now retrieve inline frames from the stack.
It can be enabled/disabled with the option: `SymGetInlineFrames` (enabled by default).

I also added a few unrelated changes:
- Added 2 missing comments for the function `SymGetSearchPath`
- Fixed a typo for the variable `offsetFromSymbol`
- The line position was incorrect because it was reporting the return line instead of the calling line : I think it is required for the inline frames.
- Updated `README.md` with Visual Studio 2022 `cmake` commands